### PR TITLE
Retire the app

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
Cause [licence changing](https://github.com/atsb/Doom64EX-Plus/issues/301) and [uncertain future](https://github.com/atsb/Doom64EX-Plus/issues/298) of Linux porting, I decided to retire this app.